### PR TITLE
Fixed path to vendor files

### DIFF
--- a/prod/php/ElasticOTel/PhpPartFacade.php
+++ b/prod/php/ElasticOTel/PhpPartFacade.php
@@ -110,8 +110,8 @@ final class PhpPartFacade
 
     private static function registerAutoloader(): bool
     {
-        $vendorDir = ProdPhpDir::$fullPath . __DIR__ . 'vendor' . (self::isInDevMode() ? '' : '_' . PHP_MAJOR_VERSION . PHP_MINOR_VERSION);
-        $vendorAutoloadPhp = $vendorDir . __DIR__ . 'autoload.php';
+        $vendorDir = ProdPhpDir::$fullPath . '/vendor' . (self::isInDevMode() ? '' : '_' . PHP_MAJOR_VERSION . PHP_MINOR_VERSION);
+        $vendorAutoloadPhp = $vendorDir . '/autoload.php';
         if (!file_exists($vendorAutoloadPhp)) {
             BootstrapStageLogger::logCritical("File $vendorAutoloadPhp does not exist", __LINE__, __FUNCTION__);
             return false;


### PR DESCRIPTION
agent installed from package is not working because of a bug in path building:
[2024-09-05 14:45:14.078129 UTC] [653/653] [CRITICAL] Bootstrap /opt/elastic/elastic-otel-php/php/ElasticOTel/BootstrapStageLogger.php 116 registerAutoloader File /opt/elastic/elastic-otel-php/php/opt/elastic/elastic-otel-php/php/ElasticOTelvendor_82/opt/elastic/elastic-otel-php/php/ElasticOTelautoload.php does not exist
