### PR TITLE
Added "php-http/discovery" to composer's "allow-plugins"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "process-timeout": 0,
         "sort-packages": true,
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "php-http/discovery": true
         }
     },
     "scripts": {


### PR DESCRIPTION
To avoid the follow prompt when executing `composer install --ignore-platform-req=ext-opentelemetry`
> `Do you trust "php-http/discovery" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?]`