### PR TITLE
Don't throw exception if instrumented function is missing

### DIFF
--- a/prod/php/ElasticOTel/InstrumentationBridge.php
+++ b/prod/php/ElasticOTel/InstrumentationBridge.php
@@ -25,7 +25,6 @@ namespace Elastic\OTel;
 
 use Closure;
 use Elastic\OTel\Util\SingletonInstanceTrait;
-use RuntimeException;
 use Throwable;
 
 /**
@@ -90,11 +89,7 @@ final class InstrumentationBridge
             return;
         }
 
-        throw new RuntimeException(
-            'elastic_otel_hook returned false'
-            . ($class === null ? '' : ('; class: ' . $dbgClassAsString))
-            . '; function: ' . $function
-        );
+        BootstrapStageLogger::logDebug('elastic_otel_hook returned false: ' . $dbgClassAsString . ', function: ' . $function, __FILE__, __LINE__, __CLASS__, __FUNCTION__);
     }
 
     private static function elasticOTelHookNoThrow(?string $class, string $function, ?Closure $pre = null, ?Closure $post = null): bool


### PR DESCRIPTION
During MySQLi instrumentation development, I realized that there might be functions introduced or deprecated depending on the PHP version. In such cases, we don’t want to throw any exceptions but instead log it at the debug level.