### PR TITLE
Dependency composer auto loader guard to force use of EDOT delivered code (#64)

### DIFF
--- a/elastic-otel-php.properties
+++ b/elastic-otel-php.properties
@@ -1,4 +1,4 @@
 version=0.3.0
 supported_php_versions=(81 82 83 84)
 php_headers_version=2.0
-logger_features_enum_values=ALL=0,MODULE=1,REQUEST=2,TRANSPORT=3,BOOTSTRAP=4,HOOKS=5,INSTRUMENTATION=6,OTEL=7
+logger_features_enum_values=ALL=0,MODULE=1,REQUEST=2,TRANSPORT=3,BOOTSTRAP=4,HOOKS=5,INSTRUMENTATION=6,OTEL=7,DEPGUARD=8

--- a/prod/native/extension/code/Hooking.h
+++ b/prod/native/extension/code/Hooking.h
@@ -28,6 +28,7 @@ class Hooking {
 public:
     using zend_execute_internal_t = void (*)(zend_execute_data *execute_data, zval *return_value);
     using zend_interrupt_function_t = void (*)(zend_execute_data *execute_data);
+    using zend_compile_file_t = zend_op_array *(*)(zend_file_handle *file_handle, int type);
 
     static Hooking &getInstance() {
         static Hooking instance;
@@ -37,11 +38,13 @@ public:
     void fetchOriginalHooks() {
         original_execute_internal_ = zend_execute_internal;
         original_zend_interrupt_function_ = zend_interrupt_function;
+        original_zend_compile_file_ = zend_compile_file;
     }
 
     void restoreOriginalHooks() {
         zend_execute_internal = original_execute_internal_;
         zend_interrupt_function = original_zend_interrupt_function_;
+        zend_compile_file = original_zend_compile_file_;
     }
 
     zend_execute_internal_t getOriginalExecuteInternal() {
@@ -52,7 +55,11 @@ public:
         return original_zend_interrupt_function_;
     }
 
-    void replaceHooks(bool enableInferredSpansHooks);
+    zend_compile_file_t getOriginalZendCompileFile() {
+        return original_zend_compile_file_;
+    }
+
+    void replaceHooks(bool enableInferredSpansHooks, bool enableDepenecyAutoloaderGuard);
 
 private:
     Hooking(Hooking const &) = delete;
@@ -61,6 +68,7 @@ private:
 
     zend_execute_internal_t original_execute_internal_ = nullptr;
     zend_interrupt_function_t original_zend_interrupt_function_ = nullptr;
+    zend_compile_file_t original_zend_compile_file_ = nullptr;
 };
 
 } // namespace elasticapm::php

--- a/prod/native/extension/code/ModuleInit.cpp
+++ b/prod/native/extension/code/ModuleInit.cpp
@@ -85,7 +85,7 @@ void elasticApmModuleInit(int moduleType, int moduleNumber) {
 
     ELOGF_DEBUG(globals->logger_, MODULE, "MINIT Replacing hooks");
     elasticapm::php::Hooking::getInstance().fetchOriginalHooks();
-    elasticapm::php::Hooking::getInstance().replaceHooks(globals->config_->get().inferred_spans_enabled);
+    elasticapm::php::Hooking::getInstance().replaceHooks(globals->config_->get().inferred_spans_enabled, globals->config_->get().dependency_autoloader_guard_enabled);
 
     zend_observer_activate();
     zend_observer_fcall_register(elasticapm::php::elasticRegisterObserver);

--- a/prod/native/extension/phpt/tests/includes/bootstrap_mock.inc
+++ b/prod/native/extension/phpt/tests/includes/bootstrap_mock.inc
@@ -15,4 +15,14 @@ final class PhpPartFacade
 
     public static function handleError(): void {
     }
+
+    public static function inferredSpans(int $durationMs, bool $internalFunction): bool {
+        return true;
+    }
+
+    public static function debugPreHook(mixed $object, array $params, ?string $class, string $function, ?string $filename, ?int $lineno): void {
+    }
+
+    public static function debugPostHook(mixed $object, array $params, mixed $retval, ?Throwable $exception): void {
+    }
 }

--- a/prod/native/libcommon/code/AgentGlobals.h
+++ b/prod/native/libcommon/code/AgentGlobals.h
@@ -37,12 +37,13 @@ class ConfigurationSnapshot;
 class LoggerSinkInterface;
 class LogSinkFile;
 class InstrumentedFunctionHooksStorageInterface;
+class DependencyAutoLoaderGuard;
 namespace transport {
 class CurlSender;
 class HttpEndpoints;
 template <typename Sender, typename Endpoints>
 class HttpTransportAsync;
-}
+} // namespace transport
 
 // clang-format off
 
@@ -64,6 +65,7 @@ public:
     std::shared_ptr<ConfigurationStorage> config_;
     std::shared_ptr<LoggerInterface> logger_;
     std::shared_ptr<PhpBridgeInterface> bridge_;
+    std::shared_ptr<DependencyAutoLoaderGuard> dependencyAutoLoaderGuard_;
     std::shared_ptr<InstrumentedFunctionHooksStorageInterface> hooksStorage_;
     std::shared_ptr<PhpSapi> sapi_;
     std::shared_ptr<InferredSpans> inferredSpans_;

--- a/prod/native/libcommon/code/ConfigurationManager.h
+++ b/prod/native/libcommon/code/ConfigurationManager.h
@@ -118,7 +118,9 @@ private:
         BUILD_METADATA(ELASTIC_OTEL_CFG_OPT_NAME_INFERRED_SPANS_REDUCTION_ENABLED, OptionMetadata::type::boolean, false),
         BUILD_METADATA(ELASTIC_OTEL_CFG_OPT_NAME_INFERRED_SPANS_STACKTRACE_ENABLED, OptionMetadata::type::boolean, false),
         BUILD_METADATA(ELASTIC_OTEL_CFG_OPT_NAME_INFERRED_SPANS_SAMPLING_INTERVAL, OptionMetadata::type::duration, false),
-        BUILD_METADATA(ELASTIC_OTEL_CFG_OPT_NAME_INFERRED_SPANS_MIN_DURATION, OptionMetadata::type::duration, false)};
+        BUILD_METADATA(ELASTIC_OTEL_CFG_OPT_NAME_INFERRED_SPANS_MIN_DURATION, OptionMetadata::type::duration, false),
+        BUILD_METADATA(ELASTIC_OTEL_CFG_OPT_NAME_DEPENDENCY_AUTOLOADER_GUARD_ENABLED, OptionMetadata::type::boolean, false)
+        };
 
     // clang-format on
 };

--- a/prod/native/libcommon/code/ConfigurationSnapshot.h
+++ b/prod/native/libcommon/code/ConfigurationSnapshot.h
@@ -47,6 +47,8 @@
 #define ELASTIC_OTEL_CFG_OPT_NAME_INFERRED_SPANS_SAMPLING_INTERVAL inferred_spans_sampling_interval
 #define ELASTIC_OTEL_CFG_OPT_NAME_INFERRED_SPANS_MIN_DURATION inferred_spans_min_duration
 
+#define ELASTIC_OTEL_CFG_OPT_NAME_DEPENDENCY_AUTOLOADER_GUARD_ENABLED dependency_autoloader_guard_enabled
+
 namespace elasticapm::php {
 
 using namespace std::string_literals;
@@ -73,6 +75,8 @@ struct ConfigurationSnapshot {
     bool ELASTIC_OTEL_CFG_OPT_NAME_INFERRED_SPANS_STACKTRACE_ENABLED = true;
     std::chrono::milliseconds ELASTIC_OTEL_CFG_OPT_NAME_INFERRED_SPANS_SAMPLING_INTERVAL = std::chrono::milliseconds(50);
     std::chrono::milliseconds ELASTIC_OTEL_CFG_OPT_NAME_INFERRED_SPANS_MIN_DURATION = std::chrono::milliseconds(0);
+
+    bool ELASTIC_OTEL_CFG_OPT_NAME_DEPENDENCY_AUTOLOADER_GUARD_ENABLED = true;
 
     uint64_t revision = 0;
 };

--- a/prod/native/libcommon/code/DependencyAutoLoaderGuard.cpp
+++ b/prod/native/libcommon/code/DependencyAutoLoaderGuard.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "DependencyAutoLoaderGuard.h"
+#include "LoggerInterface.h"
+#include "PhpBridgeInterface.h"
+
+#include <functional>
+#include <filesystem>
+#include <format>
+#include <set>
+
+namespace elasticapm::php {
+using namespace std::string_view_literals;
+
+void DependencyAutoLoaderGuard::setBootstrapPath(std::string_view bootstrapFilePath) {
+    auto [major, minor] = bridge_->getPhpVersionMajorMinor();
+    auto path = std::filesystem::path(bootstrapFilePath).parent_path();
+    path /= std::format("vendor_{}{}", major, minor);
+    vendorPath_ = path.c_str();
+    ELOGF_DEBUG(logger_, DEPGUARD, "vendor path set to: " PRsv, PRsvArg(vendorPath_));
+}
+
+bool DependencyAutoLoaderGuard::shouldDiscardFileCompilation(std::string_view fileName) {
+    try {
+        std::string compiledFilePath = std::filesystem::exists(fileName) ? std::filesystem::canonical(fileName) : fileName;
+
+        if (compiledFilePath.starts_with(vendorPath_)) {
+            return false;
+        }
+
+        auto [lastClass, lastFunction] = bridge_->getNewlyCompiledFiles(
+            [this](std::string_view name) {
+                // storing only dependencies delivered by EDOT
+                if (name.starts_with(vendorPath_)) {
+                    if (name.substr(vendorPath_.length()).starts_with("/composer/")) { // skip compsoer files - they must be compiled
+                        ELOGF_TRACE(logger_, DEPGUARD, "Skipping storage of composer files: " PRsv, PRsvArg(name));
+                        return;
+                    }
+                    compiledFiles_.insert(name);
+                    ELOGF_TRACE(logger_, DEPGUARD, "Storing file: " PRsv, PRsvArg(name));
+                }
+            },
+            lastClass_, lastFunction_);
+
+        lastClass_ = lastClass;
+        lastFunction_ = lastFunction;
+
+        if (wasDeliveredByEDOT(compiledFilePath)) {
+            ELOGF_DEBUG(logger_, DEPGUARD, "Compilation of file '" PRsv "' will be discarded", PRsvArg(compiledFilePath));
+            return true;
+        }
+
+    } catch (std::exception const &e) {
+        ELOGF_WARNING(logger_, DEPGUARD, "shouldDiscardFileCompilation of file '" PRsv "' throwed: %s", PRsvArg(fileName), e.what());
+        return false;
+    }
+
+    return false;
+}
+
+bool DependencyAutoLoaderGuard::wasDeliveredByEDOT(std::string_view fileName) const {
+    constexpr std::string_view vendor = "/vendor/"sv;
+
+    auto vendorPos = fileName.find(vendor);
+    if (vendorPos == std::string_view::npos) {
+        return false;
+    }
+
+    auto afterVendor = fileName.substr(vendorPos + vendor.size());
+
+    auto found = std::find_if(std::begin(compiledFiles_), std::end(compiledFiles_), [afterVendor, bootstrapLen = vendorPath_.length()](std::string_view storedFile) -> bool {
+        std::string_view fileView = storedFile.substr(bootstrapLen + 1); // add 1 for slash
+        if (fileView == afterVendor) {
+            return true;
+        }
+        return false;
+    });
+
+    if (found != std::end(compiledFiles_)) {
+        return true;
+    }
+    return false;
+}
+
+} // namespace elasticapm::php

--- a/prod/native/libcommon/code/DependencyAutoLoaderGuard.h
+++ b/prod/native/libcommon/code/DependencyAutoLoaderGuard.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <set>
+
+namespace elasticapm::php {
+
+class LoggerInterface;
+class PhpBridgeInterface;
+
+class DependencyAutoLoaderGuard {
+public:
+    DependencyAutoLoaderGuard(std::shared_ptr<PhpBridgeInterface> bridge, std::shared_ptr<LoggerInterface> logger) : bridge_(std::move(bridge)), logger_(std::move(logger)) {
+    }
+
+    void setBootstrapPath(std::string_view bootstrapFilePath);
+
+    void onRequestInit() {
+        clear();
+    }
+
+    void onRequestShutdown() {
+        clear();
+    }
+
+    bool shouldDiscardFileCompilation(std::string_view fileName);
+
+private:
+    bool wasDeliveredByEDOT(std::string_view fileName) const;
+
+    void clear() {
+        lastClass_ = 0;
+        lastFunction_ = 0;
+        compiledFiles_.clear();
+    }
+
+private:
+    std::shared_ptr<PhpBridgeInterface> bridge_;
+    std::shared_ptr<LoggerInterface> logger_;
+    std::set<std::string_view> compiledFiles_; // string_view is safe because we're removing data on request end, they're request scope safe
+
+    std::size_t lastClass_ = 0;
+    std::size_t lastFunction_ = 0;
+
+    std::string vendorPath_;
+};
+} // namespace elasticapm::php

--- a/prod/native/libcommon/code/PhpBridgeInterface.h
+++ b/prod/native/libcommon/code/PhpBridgeInterface.h
@@ -21,6 +21,7 @@
 
 #include "LogLevel.h"
 #include <chrono>
+#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -59,6 +60,11 @@ public:
     virtual bool isScriptRestricedByOpcacheAPI() const = 0;
     virtual bool detectOpcacheRestartPending() const = 0;
     virtual bool isOpcacheEnabled() const = 0;
+
+    virtual void getCompiledFiles(std::function<void(std::string_view)> recordFile) const = 0;
+    virtual std::pair<std::size_t, std::size_t> getNewlyCompiledFiles(std::function<void(std::string_view)> recordFile, std::size_t lastClassIndex, std::size_t lastFunctionIndex) const = 0;
+
+    virtual std::pair<int, int> getPhpVersionMajorMinor() const = 0;
 };
 
 }

--- a/prod/native/libcommon/test/DependencyAutoLoaderGuardTest.cpp
+++ b/prod/native/libcommon/test/DependencyAutoLoaderGuardTest.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "DependencyAutoLoaderGuard.h"
+#include "PhpBridgeMock.h"
+#include "Logger.h"
+
+#include <string_view>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using namespace std::literals;
+
+namespace elasticapm::php::test {
+
+using namespace std::string_view_literals;
+
+class DependencyAutoLoaderGuardTest : public ::testing::Test {
+public:
+    DependencyAutoLoaderGuardTest() {
+        if (std::getenv("ELASTIC_OTEL_DEBUG_LOG_TESTS")) {
+            auto serr = std::make_shared<elasticapm::php::LoggerSinkStdErr>();
+            serr->setLevel(logLevel_trace);
+            reinterpret_cast<elasticapm::php::Logger *>(log_.get())->attachSink(serr);
+        }
+    }
+    std::shared_ptr<LoggerInterface> log_ = std::make_shared<elasticapm::php::Logger>(std::vector<std::shared_ptr<LoggerSinkInterface>>());
+    std::shared_ptr<PhpBridgeMock> bridge_{std::make_shared<::testing::StrictMock<PhpBridgeMock>>()};
+    DependencyAutoLoaderGuard guard_{bridge_, log_};
+};
+
+TEST_F(DependencyAutoLoaderGuardTest, discardAppFileBecauseItWasDeliveredByEDOT) {
+    EXPECT_CALL(*bridge_, getPhpVersionMajorMinor()).Times(::testing::Exactly(1)).WillOnce(::testing::Return(std::pair<int, int>(8, 4)));
+
+    guard_.setBootstrapPath("/elatic/prod/php/bootstrap.php");
+
+    ASSERT_FALSE(guard_.shouldDiscardFileCompilation("/elatic/prod/php/vendor_84/first-package/test.php"));  // file from elastic scope - no action
+    ASSERT_FALSE(guard_.shouldDiscardFileCompilation("/elatic/prod/php/vendor_84/second-package/test.php")); // file from elastic scope - no action
+
+    // clang-format off
+    EXPECT_CALL(*bridge_, getNewlyCompiledFiles(::testing::_, 0, 0)).Times(::testing::Exactly(1)).WillOnce(
+        ::testing::DoAll(
+            ::testing::InvokeArgument<0>("/elatic/prod/php/vendor_84/first-package/test.php"sv), // we have that file in cache
+            ::testing::InvokeArgument<0>("/elatic/prod/php/vendor_84/second-package/test.php"sv), // we have that file in cache
+            ::testing::Return(std::pair<int, int>(2, 1)))); // returns index in class/file hashmaps
+    // clang-format on
+
+    ASSERT_TRUE(guard_.shouldDiscardFileCompilation("/app/vendor/first-package/test.php")); // file from app scope - test it - should discard - file is EDOT delivered
+}
+
+TEST_F(DependencyAutoLoaderGuardTest, discardSecondAppFileBecauseItWasDeliveredByEDOT) {
+    EXPECT_CALL(*bridge_, getPhpVersionMajorMinor()).Times(::testing::Exactly(1)).WillOnce(::testing::Return(std::pair<int, int>(8, 4)));
+
+    guard_.setBootstrapPath("/elatic/prod/php/bootstrap.php");
+
+    ASSERT_FALSE(guard_.shouldDiscardFileCompilation("/elatic/prod/php/vendor_84/first-package/test.php"));  // file from elastic scope - no action
+    ASSERT_FALSE(guard_.shouldDiscardFileCompilation("/elatic/prod/php/vendor_84/second-package/test.php")); // file from elastic scope - no action
+
+    // clang-format off
+    EXPECT_CALL(*bridge_, getNewlyCompiledFiles(::testing::_, 0, 0)).Times(::testing::Exactly(1)).WillOnce(
+        ::testing::DoAll(
+            ::testing::InvokeArgument<0>("/elatic/prod/php/vendor_84/first-package/test.php"sv), // we have that file in cache
+            ::testing::InvokeArgument<0>("/elatic/prod/php/vendor_84/second-package/test.php"sv), // we have that file in cache
+            ::testing::Return(std::pair<int, int>(2, 1)))); // returns index in class/file hashmaps
+    // clang-format on
+
+    ASSERT_TRUE(guard_.shouldDiscardFileCompilation("/app/vendor/second-package/test.php")); // file from app scope - test it - should discard - file is EDOT delivered
+}
+
+TEST_F(DependencyAutoLoaderGuardTest, getCompiledFilesListProgressively) {
+    EXPECT_CALL(*bridge_, getPhpVersionMajorMinor()).Times(::testing::Exactly(1)).WillOnce(::testing::Return(std::pair<int, int>(8, 4)));
+
+    guard_.setBootstrapPath("/elatic/prod/php/bootstrap.php");
+
+    ASSERT_FALSE(guard_.shouldDiscardFileCompilation("/elatic/prod/php/vendor_84/first-package/test.php"));  // file from elastic scope - no action
+    ASSERT_FALSE(guard_.shouldDiscardFileCompilation("/elatic/prod/php/vendor_84/second-package/test.php")); // file from elastic scope - no action
+
+    ::testing::InSequence s;
+
+    // clang-format off
+    EXPECT_CALL(*bridge_, getNewlyCompiledFiles(::testing::_, 0, 0)).Times(::testing::Exactly(1)).WillOnce(
+        ::testing::DoAll(
+            ::testing::InvokeArgument<0>("/elatic/prod/php/vendor_84/first-package/test.php"sv), // we have that file in cache
+            ::testing::Return(std::pair<int, int>(10, 20)))); // returns index in class/file hashmaps
+    // clang-format on
+
+    ASSERT_TRUE(guard_.shouldDiscardFileCompilation("/app/vendor/first-package/test.php")); // file from app scope - test it - should discard - file is EDOT delivered
+
+    // clang-format off
+    EXPECT_CALL(*bridge_, getNewlyCompiledFiles(::testing::_, 10, 20)).Times(::testing::Exactly(1)).WillOnce(
+        ::testing::DoAll(
+            ::testing::InvokeArgument<0>("/elatic/prod/php/vendor_84/second-package/test.php"sv), // we have that file in cache
+            ::testing::Return(std::pair<int, int>(11, 21)))); // returns index in class/file hashmaps
+    // clang-format on
+
+    ASSERT_TRUE(guard_.shouldDiscardFileCompilation("/app/vendor/second-package/test.php")); // file from app scope - test it - should discard - file is EDOT delivered
+
+    // clang-format off
+    EXPECT_CALL(*bridge_, getNewlyCompiledFiles(::testing::_, 11, 21)).Times(::testing::Exactly(1)).WillOnce(
+        ::testing::DoAll(
+            ::testing::Return(std::pair<int, int>(11, 21)))); // returns index in class/file hashmaps
+    // clang-format on
+
+    ASSERT_FALSE(guard_.shouldDiscardFileCompilation("/app/vendor/third-package/test.php")); // file from app scope - test it - should NOT discard - file is NOT EDOT delivered
+}
+
+TEST_F(DependencyAutoLoaderGuardTest, fileNotInVendorFolder) {
+    EXPECT_CALL(*bridge_, getPhpVersionMajorMinor()).Times(::testing::Exactly(1)).WillOnce(::testing::Return(std::pair<int, int>(8, 4)));
+    guard_.setBootstrapPath("/elatic/prod/php/bootstrap.php");
+
+    ASSERT_FALSE(guard_.shouldDiscardFileCompilation("/elatic/prod/php/vendor_84/first-package/test.php")); // file from elastic scope - no action
+
+    ::testing::InSequence s;
+
+    // clang-format off
+    EXPECT_CALL(*bridge_, getNewlyCompiledFiles(::testing::_, 0, 0)).Times(::testing::Exactly(1)).WillOnce(
+        ::testing::DoAll(
+            ::testing::InvokeArgument<0>("/elatic/prod/php/vendor_84/first-package/test.php"sv), // we have that file in cache
+            ::testing::Return(std::pair<int, int>(10, 20)))); // returns index in class/file hashmaps
+    // clang-format on
+
+    ASSERT_FALSE(guard_.shouldDiscardFileCompilation("/app/first-package/test.php")); // file from app scope - test it - should discard - file is EDOT delivered
+}
+
+TEST_F(DependencyAutoLoaderGuardTest, wrongVendorFolder_shouldntHappen) {
+    EXPECT_CALL(*bridge_, getPhpVersionMajorMinor()).Times(::testing::Exactly(1)).WillOnce(::testing::Return(std::pair<int, int>(8, 4)));
+
+    guard_.setBootstrapPath("/elatic/prod/php/bootstrap.php");
+
+    ::testing::InSequence s;
+
+    // clang-format off
+    EXPECT_CALL(*bridge_, getNewlyCompiledFiles(::testing::_, 0, 0)).Times(::testing::Exactly(1)).WillOnce(
+        ::testing::DoAll(
+            ::testing::InvokeArgument<0>("/elatic/prod/php/vendor_80/first-package/test.php"sv), // we have that file in cache
+            ::testing::Return(std::pair<int, int>(2, 1)))); // returns index in class/file hashmaps
+    // clang-format on
+
+    ASSERT_FALSE(guard_.shouldDiscardFileCompilation("/elatic/prod/php/vendor_80/first-package/test.php")); // file NOT from elastic scope - wrong vendor folder
+
+    // clang-format off
+    EXPECT_CALL(*bridge_, getNewlyCompiledFiles(::testing::_, 2, 1)).Times(::testing::Exactly(1)).WillOnce(
+        ::testing::DoAll(
+            ::testing::Return(std::pair<int, int>(2, 1)))); // returns index in class/file hashmaps
+    // clang-format on
+
+    ASSERT_FALSE(guard_.shouldDiscardFileCompilation("/app/vendor/first-package/test.php"));
+}
+
+} // namespace elasticapm::php::test

--- a/prod/native/libcommon/test/PhpBridgeMock.h
+++ b/prod/native/libcommon/test/PhpBridgeMock.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "PhpBridgeInterface.h"
+#include <gmock/gmock.h>
+
+namespace elasticapm::php::test {
+
+class PhpBridgeMock : public PhpBridgeInterface {
+public:
+    MOCK_METHOD(bool, callInferredSpans, (std::chrono::milliseconds duration), (const, override));
+    MOCK_METHOD(bool, callPHPSideEntryPoint, (LogLevel logLevel, std::chrono::time_point<std::chrono::system_clock> requestInitStart), (const, override));
+    MOCK_METHOD(bool, callPHPSideExitPoint, (), (const, override));
+    MOCK_METHOD(bool, callPHPSideErrorHandler, (int type, std::string_view errorFilename, uint32_t errorLineno, std::string_view message), (const, override));
+
+    MOCK_METHOD(std::vector<phpExtensionInfo_t>, getExtensionList, (), (const, override));
+    MOCK_METHOD(std::string, getPhpInfo, (), (const, override));
+
+    MOCK_METHOD(std::string_view, getPhpSapiName, (), (const, override));
+
+    MOCK_METHOD(std::optional<std::string_view>, getCurrentExceptionMessage, (), (const, override));
+
+    MOCK_METHOD(void, compileAndExecuteFile, (std::string_view fileName), (const, override));
+
+    MOCK_METHOD(void, enableAccessToServerGlobal, (), (const, override));
+
+    MOCK_METHOD(bool, detectOpcachePreload, (), (const, override));
+    MOCK_METHOD(bool, isScriptRestricedByOpcacheAPI, (), (const, override));
+    MOCK_METHOD(bool, detectOpcacheRestartPending, (), (const, override));
+    MOCK_METHOD(bool, isOpcacheEnabled, (), (const, override));
+
+    MOCK_METHOD(void, getCompiledFiles, (std::function<void(std::string_view)> recordFile), (const, override));
+    MOCK_METHOD((std::pair<std::size_t, std::size_t>), getNewlyCompiledFiles, (std::function<void(std::string_view)> recordFile, std::size_t lastClassIndex, std::size_t lastFunctionIndex), (const, override));
+
+    MOCK_METHOD((std::pair<int, int>), getPhpVersionMajorMinor, (), (const, override));
+};
+
+} // namespace elasticapm::php::test

--- a/prod/native/libphpbridge/code/PhpBridge.h
+++ b/prod/native/libphpbridge/code/PhpBridge.h
@@ -58,6 +58,10 @@ public:
     bool detectOpcacheRestartPending() const final;
     bool isOpcacheEnabled() const final;
 
+    void getCompiledFiles(std::function<void(std::string_view)> recordFile) const final;
+    std::pair<std::size_t, std::size_t> getNewlyCompiledFiles(std::function<void(std::string_view)> recordFile, std::size_t lastClassIndex, std::size_t lastFunctionIndex) const final;
+
+    std::pair<int, int> getPhpVersionMajorMinor() const final;
 
 private:
     std::shared_ptr<elasticapm::php::LoggerInterface> log_;

--- a/prod/native/phpbridge_extension/code/BridgeModuleFunctions.cpp
+++ b/prod/native/phpbridge_extension/code/BridgeModuleFunctions.cpp
@@ -350,6 +350,39 @@ PHP_FUNCTION(getCurrentException) {
     RETURN_COPY(zv.get());
 }
 
+PHP_FUNCTION(getCompiledFiles) {
+    BRIDGE_G(globals)->bridge.getCompiledFiles([](std::string_view file) { BRIDGE_G(globals)->logger->printf(LogLevel::logLevel_info, PRsv, PRsvArg(file)); });
+    RETURN_NULL();
+}
+
+PHP_FUNCTION(getNewlyCompiledFiles) {
+    long lastClass = 0;
+    long lastFunction = 0;
+
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+    Z_PARAM_LONG(lastClass)
+    Z_PARAM_LONG(lastFunction)
+    ZEND_PARSE_PARAMETERS_END();
+
+    auto [retLastClass, retLastFunc] = BRIDGE_G(globals)->bridge.getNewlyCompiledFiles([](std::string_view file) { BRIDGE_G(globals)->logger->printf(LogLevel::logLevel_info, PRsv, PRsvArg(file)); }, lastClass, lastFunction);
+
+    zval zlastClass, zlastFunc;
+    ZVAL_LONG(&zlastClass, retLastClass);
+    ZVAL_LONG(&zlastFunc, retLastFunc);
+
+    RETURN_ARR(zend_new_pair(&zlastClass, &zlastFunc));
+}
+
+PHP_FUNCTION(getPhpVersionMajorMinor) {
+    auto [major, minor] = BRIDGE_G(globals)->bridge.getPhpVersionMajorMinor();
+
+    zval zMajor, zMinor;
+    ZVAL_LONG(&zMajor, major);
+    ZVAL_LONG(&zMinor, minor);
+
+    RETURN_ARR(zend_new_pair(&zMajor, &zMinor));
+}
+
 ZEND_BEGIN_ARG_INFO(no_paramters_arginfo, 0)
 ZEND_END_ARG_INFO()
 
@@ -376,6 +409,10 @@ const zend_function_entry phpbridge_functions[] = {
     PHP_FE( getScopeNameOrThis, no_paramters_arginfo )
     PHP_FE( getExceptionName, no_paramters_arginfo )
     PHP_FE( getCurrentException, no_paramters_arginfo )
+
+    PHP_FE( getCompiledFiles, no_paramters_arginfo )
+    PHP_FE( getNewlyCompiledFiles, no_paramters_arginfo )
+    PHP_FE( getPhpVersionMajorMinor, no_paramters_arginfo )
 
     PHP_FE_END
 };

--- a/prod/native/phpbridge_extension/phpt/tests/getCompiledFiles.phpt
+++ b/prod/native/phpbridge_extension/phpt/tests/getCompiledFiles.phpt
@@ -1,0 +1,28 @@
+--TEST--
+getCompiledFiles
+--INI--
+extension=/elastic/phpbridge.so
+--FILE--
+<?php
+declare(strict_types=1);
+
+class TestClass {
+  public $testProperty = "hello";
+}
+
+getCompiledFiles();
+
+echo "require\n";
+require("includes/someClass.inc");
+
+getCompiledFiles();
+
+
+echo 'Test completed';
+?>
+--EXPECTF--
+[%a] %a/tests/getCompiledFiles.php
+require
+[%a] %a/tests/getCompiledFiles.php
+[%a] %a/tests/includes/someClass.inc
+Test completed

--- a/prod/native/phpbridge_extension/phpt/tests/getNewlyCompiledFiles.phpt
+++ b/prod/native/phpbridge_extension/phpt/tests/getNewlyCompiledFiles.phpt
@@ -1,0 +1,31 @@
+--TEST--
+getNewlyCompiledFiles
+--INI--
+extension=/elastic/phpbridge.so
+--FILE--
+<?php
+declare(strict_types=1);
+
+class TestClass {
+  public $testProperty = "hello";
+}
+
+$indexes = getNewlyCompiledFiles(0, 0);
+
+
+echo "require\n";
+require("includes/someClass.inc");
+
+$newIndexes = getNewlyCompiledFiles($indexes[0], $indexes[1]);
+
+if ($newIndexes[1] == $indexes[1]) {
+  echo "FAILURE, function index not changed\n";
+}
+
+echo 'Test completed';
+?>
+--EXPECTF--
+[%a] %a/tests/getNewlyCompiledFiles.php
+require
+[%a] %a/tests/includes/someClass.inc
+Test completed

--- a/prod/native/phpbridge_extension/phpt/tests/getPhpVersionMajorMinor.phpt
+++ b/prod/native/phpbridge_extension/phpt/tests/getPhpVersionMajorMinor.phpt
@@ -1,0 +1,23 @@
+--TEST--
+getPhpVersionMajorMinor
+--INI--
+extension=/elastic/phpbridge.so
+--FILE--
+<?php
+declare(strict_types=1);
+
+class TestClass {
+  public $testProperty = "hello";
+}
+
+$versions = getPhpVersionMajorMinor();
+
+if ($versions[0] == PHP_MAJOR_VERSION && $versions[1] == PHP_MINOR_VERSION) {
+  echo "ALL OK\n";
+}
+
+echo 'Test completed';
+?>
+--EXPECTF--
+ALL OK
+Test completed

--- a/prod/native/phpbridge_extension/phpt/tests/includes/someClass.inc
+++ b/prod/native/phpbridge_extension/phpt/tests/includes/someClass.inc
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+class SomeClass {
+  public $testProperty = "hello";
+}
+
+function hohoho() {
+
+}


### PR DESCRIPTION
Example output from phpstan run in otel contrib 
With feature enabled:
```
[EDOT] [2025-02-11 15:39:05.075699 UTC] [242752/242752] [DEBUG   ] [DEPGUARD] Compilation of file '/home/paplo/sources/otel/opentelemetry-php-contrib/src/Instrumentation/MySqli/vendor/symfony/deprecation-contracts/function.php' will be discarded
[EDOT] [2025-02-11 15:39:05.078938 UTC] [242752/242752] [DEBUG   ] [DEPGUARD] Compilation of file '/home/paplo/sources/otel/opentelemetry-php-contrib/src/Instrumentation/MySqli/vendor/open-telemetry/api/Trace/functions.php' will be discarded
[EDOT] [2025-02-11 15:39:05.079243 UTC] [242752/242752] [DEBUG   ] [DEPGUARD] Compilation of file '/home/paplo/sources/otel/opentelemetry-php-contrib/src/Instrumentation/MySqli/vendor/ramsey/uuid/src/functions.php' will be discarded
[EDOT] [2025-02-11 15:39:05.079835 UTC] [242752/242752] [DEBUG   ] [DEPGUARD] Compilation of file '/home/paplo/sources/otel/opentelemetry-php-contrib/src/Instrumentation/MySqli/vendor/open-telemetry/sdk/Common/Util/functions.php' will be discarded
...
...
Note: Using configuration file /home/paplo/sources/otel/opentelemetry-php-contrib/src/Instrumentation/MySqli/phpstan.neon.dist.
 4/4 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


                                                                                                                        
 [OK] No errors                                                                                                         
                                                                                                                        

```

With feature disabled:
```
PHP Fatal error:  Cannot redeclare function OpenTelemetry\API\Trace\trace() (previously declared in /home/paplo/sources/elastic-otel-php/prod/php/vendor_84/open-telemetry/api/Trace/functions.php:23) in /home/paplo/sources/otel/opentelemetry-php-contrib/src/Instrumentation/MySqli/vendor/open-telemetry/api/Trace/functions.php on line 23
```