### PR TITLE
Fix static analysis failures (v2 for PR #213)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "slim/slim": "*"
     },
     "require-dev": {
-        "google/protobuf": "4.30.2",
         "ext-ctype": "*",
         "ext-curl": "*",
         "ext-mysqli": "*",

--- a/tests/ElasticOTelTests/ComponentTests/Util/IntakeApiRequestDeserializer.php
+++ b/tests/ElasticOTelTests/ComponentTests/Util/IntakeApiRequestDeserializer.php
@@ -31,7 +31,7 @@ use ElasticOTelTests\Util\HttpContentTypes;
 use ElasticOTelTests\Util\HttpHeaderNames;
 use ElasticOTelTests\Util\Log\LogCategoryForTests;
 use ElasticOTelTests\Util\Log\Logger;
-use Google\Protobuf\Internal\RepeatedField;
+use Google\Protobuf\RepeatedField;
 use OpenTelemetry\Contrib\Otlp\ProtobufSerializer;
 use Opentelemetry\Proto\Collector\Trace\V1\ExportTraceServiceRequest;
 use Opentelemetry\Proto\Trace\V1\ResourceSpans;
@@ -67,9 +67,11 @@ final class IntakeApiRequestDeserializer
     }
 
     /**
-     * @param array<string, RepeatedField> $repeatedFieldNameToObj
+     * @template T
      *
-     * @return array<string, int>
+     * @param array<string, RepeatedField<T>> $repeatedFieldNameToObj
+     *
+     * @return array<string, mixed>
      */
     private static function buildLogContextForRepeatedField(array $repeatedFieldNameToObj): array
     {
@@ -85,22 +87,37 @@ final class IntakeApiRequestDeserializer
         $loggerProxyDebug = $logger->ifDebugLevelEnabledNoLine(__FUNCTION__);
 
         $resourceSpansRepeatedField = $exportTraceServiceRequest->getResourceSpans();
+        /**
+         * Google\Protobuf\Internal\RepeatedField is deprecated, and Google\Protobuf\RepeatedField is used instead.
+         *
+         * @var RepeatedField<ResourceSpans> $resourceSpansRepeatedField
+         */
         $loggerProxyDebug && $loggerProxyDebug->log(__LINE__, '', self::buildLogContextForRepeatedField(compact('resourceSpansRepeatedField')));
 
         $result = [];
         foreach ($resourceSpansRepeatedField as $resourceSpans) {
             $loggerProxyDebug && $loggerProxyDebug->log(__LINE__, '', compact('resourceSpans'));
-            Assert::assertInstanceOf(ResourceSpans::class, $resourceSpans);
+            Assert::assertInstanceOf(ResourceSpans::class, $resourceSpans); // @phpstan-ignore staticMethod.alreadyNarrowedType
             $scopeSpansRepeatedField = $resourceSpans->getScopeSpans();
+            /**
+             * Google\Protobuf\Internal\RepeatedField is deprecated, and Google\Protobuf\RepeatedField is used instead.
+             *
+             * @var RepeatedField<ScopeSpans> $scopeSpansRepeatedField
+             */
             $loggerProxyDebug && $loggerProxyDebug->log(__LINE__, '', self::buildLogContextForRepeatedField(compact('scopeSpansRepeatedField')));
             foreach ($scopeSpansRepeatedField as $scopeSpans) {
                 $loggerProxyDebug && $loggerProxyDebug->log(__LINE__, '', compact('scopeSpans'));
-                Assert::assertInstanceOf(ScopeSpans::class, $scopeSpans);
+                Assert::assertInstanceOf(ScopeSpans::class, $scopeSpans); // @phpstan-ignore staticMethod.alreadyNarrowedType
                 $spansRepeatedField = $scopeSpans->getSpans();
+                /**
+                 * Google\Protobuf\Internal\RepeatedField is deprecated, and Google\Protobuf\RepeatedField is used instead.
+                 *
+                 * @var RepeatedField<OTelProtoSpan> $spansRepeatedField
+                 */
                 $loggerProxyDebug && $loggerProxyDebug->log(__LINE__, '', self::buildLogContextForRepeatedField(compact('spansRepeatedField')));
                 foreach ($spansRepeatedField as $otelProtoSpan) {
                     $loggerProxyDebug && $loggerProxyDebug->log(__LINE__, '', compact('otelProtoSpan'));
-                    Assert::assertInstanceOf(OTelProtoSpan::class, $otelProtoSpan);
+                    Assert::assertInstanceOf(OTelProtoSpan::class, $otelProtoSpan); // @phpstan-ignore staticMethod.alreadyNarrowedType
                     $span = new Span($otelProtoSpan);
                     if (($reason = self::reasonToDiscard($span)) !== null) {
                         $loggerProxyDebug && $loggerProxyDebug->log(__LINE__, 'Span discarded', compact('reason', 'span'));

--- a/tests/ElasticOTelTests/ComponentTests/Util/Span.php
+++ b/tests/ElasticOTelTests/ComponentTests/Util/Span.php
@@ -50,7 +50,11 @@ final class Span implements LoggableInterface
 
     public function __construct(OTelProtoSpan $protoSpan)
     {
-        $this->attributes = new SpanAttributes($protoSpan->getAttributes());
+        /**
+         * @noinspection PhpParamsInspection
+         * Google\Protobuf\Internal\RepeatedField is deprecated, and Google\Protobuf\RepeatedField is used instead.
+         */
+        $this->attributes = new SpanAttributes($protoSpan->getAttributes()); // @phpstan-ignore argument.type
         $this->id = self::convertId($protoSpan->getSpanId());
         $this->kind = SpanKind::fromOTelProtoSpanKind($protoSpan->getKind());
         $this->name = $protoSpan->getName();

--- a/tests/ElasticOTelTests/ComponentTests/Util/SpanAttributes.php
+++ b/tests/ElasticOTelTests/ComponentTests/Util/SpanAttributes.php
@@ -33,7 +33,7 @@ use ElasticOTelTests\Util\Log\LoggableInterface;
 use ElasticOTelTests\Util\Log\LoggableToString;
 use ElasticOTelTests\Util\Log\LogStreamInterface;
 use ElasticOTelTests\Util\TextUtilForTests;
-use Google\Protobuf\Internal\RepeatedField as ProtobufRepeatedField;
+use Google\Protobuf\RepeatedField as ProtobufRepeatedField;
 use Opentelemetry\Proto\Common\V1\KeyValue as OTelProtoKeyValue;
 use Override;
 use PHPUnit\Framework\Assert;
@@ -48,6 +48,9 @@ final class SpanAttributes implements ArrayReadInterface, Countable, LoggableInt
     /** @var array<string, AttributeValue> $keyToValueMap */
     private readonly array $keyToValueMap;
 
+    /**
+     * @param ProtobufRepeatedField<OTelProtoKeyValue> $protobufRepeatedField
+     */
     public function __construct(ProtobufRepeatedField $protobufRepeatedField)
     {
         $this->keyToValueMap = self::convertProtobufRepeatedFieldToMap($protobufRepeatedField);
@@ -73,7 +76,9 @@ final class SpanAttributes implements ArrayReadInterface, Countable, LoggableInt
                 return null;
             }
             $result = [];
-            foreach ($arrayValue->getValues() as $repeatedFieldSubValue) {
+            // Google\Protobuf\Internal\RepeatedField is deprecated, and Google\Protobuf\RepeatedField is used instead.
+            // Google\Protobuf\RepeatedField implements IteratorAggregate so it's iterable.
+            foreach ($arrayValue->getValues() as $repeatedFieldSubValue) { // @phpstan-ignore foreach.nonIterable
                 $result[] = $repeatedFieldSubValue;
             }
             return $result;
@@ -105,7 +110,9 @@ final class SpanAttributes implements ArrayReadInterface, Countable, LoggableInt
                 return null;
             }
             $result = [];
-            foreach ($kvListValue->getValues() as $repeatedFieldSubKey => $repeatedFieldSubValue) {
+            // Google\Protobuf\Internal\RepeatedField is deprecated, and Google\Protobuf\RepeatedField is used instead.
+            // Google\Protobuf\RepeatedField implements IteratorAggregate so it's iterable.
+            foreach ($kvListValue->getValues() as $repeatedFieldSubKey => $repeatedFieldSubValue) { // @phpstan-ignore foreach.nonIterable
                 Assert::assertTrue(is_int($repeatedFieldSubKey) || is_string($repeatedFieldSubKey));
                 Assert::assertArrayNotHasKey($repeatedFieldSubKey, $result);
                 $result[$repeatedFieldSubKey] = $repeatedFieldSubValue;
@@ -121,7 +128,7 @@ final class SpanAttributes implements ArrayReadInterface, Countable, LoggableInt
     }
 
     /**
-     * @param ProtobufRepeatedField $protobufRepeatedField
+     * @param ProtobufRepeatedField<OTelProtoKeyValue> $protobufRepeatedField
      *
      * @return array<string, AttributeValue>
      */
@@ -132,7 +139,7 @@ final class SpanAttributes implements ArrayReadInterface, Countable, LoggableInt
         $result = [];
         foreach ($protobufRepeatedField as $keyValue) {
             $dbgCtx->add(compact('keyValue'));
-            Assert::assertInstanceOf(OTelProtoKeyValue::class, $keyValue);
+            Assert::assertInstanceOf(OTelProtoKeyValue::class, $keyValue); // @phpstan-ignore staticMethod.alreadyNarrowedType
             Assert::assertArrayNotHasKey($keyValue->getKey(), $result);
             $result[$keyValue->getKey()] = self::extractValue($keyValue);
         }

--- a/tools/build/build_packages.sh
+++ b/tools/build/build_packages.sh
@@ -105,12 +105,7 @@ test_package() {
                 php:${PHP_VERSION} sh -c "ls /source/build/packages && ${INSTALL_SMOKE} && ${TEST_LICENSE_FILES} && ${UNINSTALL_SMOKE} && ls -alR /opt/elastic"
         ;;
         "rpm")
-            local remi_release_rpm_version
-            remi_release_rpm_version=$(grep -oP '(?<=release )\d+\.\d+' /etc/redhat-release)
-            if [ "${remi_release_rpm_version}" == "9.6" ] ; then
-                remi_release_rpm_version="9.5"
-            fi
-            local INSTALL_PHP="cat /etc/redhat-release && dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-\$(grep -oP '(?<=release )\d+' /etc/redhat-release).noarch.rpm -y && dnf install https://rpms.remirepo.net/enterprise/remi-release-\${remi_release_rpm_version}.rpm -y && dnf install --setopt=install_weak_deps=False -y php${PHP_VERSION//./} php${PHP_VERSION//./}-syspaths"
+            local INSTALL_PHP="cat /etc/redhat-release && dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-\$(grep -oP '(?<=release )\d+' /etc/redhat-release).noarch.rpm -y && dnf install https://rpms.remirepo.net/enterprise/remi-release-\$(grep -oP '(?<=release )\d+\.\d+' /etc/redhat-release).rpm -y && dnf install --setopt=install_weak_deps=False -y php${PHP_VERSION//./} php${PHP_VERSION//./}-syspaths"
             local INSTALL_SMOKE="rpm -ivh /source/build/packages/${PKG_FILENAME} && php /source/packaging/test/smokeTest.php"
             local UNINSTALL_SMOKE="rpm -ve elastic-otel-php && php /source/packaging/test/smokeTestUninstalled.php"
 

--- a/tools/build/build_packages.sh
+++ b/tools/build/build_packages.sh
@@ -105,7 +105,12 @@ test_package() {
                 php:${PHP_VERSION} sh -c "ls /source/build/packages && ${INSTALL_SMOKE} && ${TEST_LICENSE_FILES} && ${UNINSTALL_SMOKE} && ls -alR /opt/elastic"
         ;;
         "rpm")
-            local INSTALL_PHP="cat /etc/redhat-release && dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-\$(grep -oP '(?<=release )\d+' /etc/redhat-release).noarch.rpm -y && dnf install https://rpms.remirepo.net/enterprise/remi-release-\$(grep -oP '(?<=release )\d+\.\d+' /etc/redhat-release).rpm -y && dnf install --setopt=install_weak_deps=False -y php${PHP_VERSION//./} php${PHP_VERSION//./}-syspaths"
+            local remi_release_rpm_version
+            remi_release_rpm_version=$(grep -oP '(?<=release )\d+\.\d+' /etc/redhat-release)
+            if [ "${remi_release_rpm_version}" == "9.6" ] ; then
+                remi_release_rpm_version="9.5"
+            fi
+            local INSTALL_PHP="cat /etc/redhat-release && dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-\$(grep -oP '(?<=release )\d+' /etc/redhat-release).noarch.rpm -y && dnf install https://rpms.remirepo.net/enterprise/remi-release-\${remi_release_rpm_version}.rpm -y && dnf install --setopt=install_weak_deps=False -y php${PHP_VERSION//./} php${PHP_VERSION//./}-syspaths"
             local INSTALL_SMOKE="rpm -ivh /source/build/packages/${PKG_FILENAME} && php /source/packaging/test/smokeTest.php"
             local UNINSTALL_SMOKE="rpm -ve elastic-otel-php && php /source/packaging/test/smokeTestUninstalled.php"
 


### PR DESCRIPTION
Fixes #222

Fixed static analysis failures caused by Google\Protobuf\Internal\RepeatedField deprecation

The first attempt to fix this issue was made in PR #213