### PR TITLE
Improved link to docs from root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ With EDOT PHP, you get all the features of the OpenTelemetry PHP agent, plus:
 
 📚 **Want to get started?**
 
-Check out the official documentation at [https://www.elastic.co/docs/reference/opentelemetry/edot-sdks/php/index.html](https://www.elastic.co/docs/reference/opentelemetry/edot-sdks/php/index.html)
+Check out the official documentation at [https://www.elastic.co/docs/reference/opentelemetry/edot-sdks/php](https://www.elastic.co/docs/reference/opentelemetry/edot-sdks/php)


### PR DESCRIPTION
The link before this change ([https://www.elastic.co/docs/reference/opentelemetry/edot-sdks/php/index.html])(https://www.elastic.co/docs/reference/opentelemetry/edot-sdks/php/index.html) leaves the menu on the right hand side closed:

<img width="1465" height="772" alt="image" src="https://github.com/user-attachments/assets/6f06a2db-e11e-40a4-83bf-ca6cdb8ebb32" />


The link after this change ([https://www.elastic.co/docs/reference/opentelemetry/edot-sdks/php](https://www.elastic.co/docs/reference/opentelemetry/edot-sdks/php)) causes the menu on the right hand side to open at the corresponding entry:

<img width="1448" height="558" alt="image" src="https://github.com/user-attachments/assets/d544c07b-557a-4484-b902-26c101ee309b" />
