### PR TITLE
Start using the snyk service account credentials

### DIFF
--- a/.github/workflows/scan-snyk.yml
+++ b/.github/workflows/scan-snyk.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      SNYK_TOKEN: ${{ secrets.SNYK_API_KEY }}
+      SNYK_TOKEN: ${{ secrets.SNYK_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v6
       - name: Scan for vulnerabilities with Snyk


### PR DESCRIPTION
## Summary

To avoid using personal auth tokens, this PR change the Snyk credentials to start using the auth token defined for a service account.