### PR TITLE
Add Vale docs linting support

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -11,6 +11,7 @@ jobs:
   docs-preview:
     uses: elastic/docs-builder/.github/workflows/preview-build.yml@main
     with:
+      enable-vale-linting: true
       path-pattern: docs/**
     permissions:
       id-token: write


### PR DESCRIPTION
This PR adds support for Vale docs linting to the repository. Linting only triggers when Markdown files inside the docs folder are edited. Vale linting never blocks pull requests. For more information, refer to [Vale linter](https://www.elastic.co/docs/contribute-docs/vale-linter).

Contributes to https://github.com/elastic/docs-content-internal/issues/667