### PR TITLE
Implement OpAMP remote config parsing and vendor customizations (#272)

### DIFF
--- a/elastic_prod/native/libelastic/ElasticConfigProvider.cpp
+++ b/elastic_prod/native/libelastic/ElasticConfigProvider.cpp
@@ -142,7 +142,6 @@ ElasticConfigProvider::optionsMap_t ElasticConfigProvider::remapOptions(optionsM
             }
 
             result[STRINGIFY_HELPER(OTEL_PHP_LOG_LEVEL)] = loglevel;
-            result[STRINGIFY_HELPER(OTEL_PHP_LOG_LEVEL)] = loglevel;
             result[STRINGIFY_HELPER(OTEL_PHP_LOG_LEVEL_STDERR)] = loglevel;
             result[STRINGIFY_HELPER(OTEL_PHP_LOG_LEVEL_SYSLOG)] = loglevel;
             result[STRINGIFY_HELPER(OTEL_PHP_LOG_LEVEL_FILE)] = loglevel;

--- a/elastic_prod/native/libelastic/ElasticConfigProvider.cpp
+++ b/elastic_prod/native/libelastic/ElasticConfigProvider.cpp
@@ -20,8 +20,10 @@
 #include "ElasticConfigProvider.h"
 
 #include <cstdlib>
+#include <nlohmann/json.hpp>
 
 #include "AutoZval.h"
+#include "ConfigurationSnapshot.h"
 
 extern "C" {
 #include <main/php.h>
@@ -29,54 +31,150 @@ extern "C" {
 
 namespace elastic::otel {
 
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
 static constexpr std::string_view UPSTREAM_INI_PREFIX = "opentelemetry_distro.";
 static constexpr std::string_view UPSTREAM_ENV_PREFIX = "OTEL_PHP_";
 static constexpr std::string_view ELASTIC_INI_PREFIX = "elastic_otel.";
 static constexpr std::string_view ELASTIC_ENV_PREFIX = "ELASTIC_OTEL_";
 
 std::optional<std::string> ElasticConfigProvider::getEnvironmentOptionValue(std::string_view name) {
-  if (name.substr(0, UPSTREAM_ENV_PREFIX.size()) != UPSTREAM_ENV_PREFIX) {
-    return std::nullopt;
-  }
+    if (name.substr(0, UPSTREAM_ENV_PREFIX.size()) != UPSTREAM_ENV_PREFIX) {
+        return std::nullopt;
+    }
 
-  auto shortName = name.substr(UPSTREAM_ENV_PREFIX.size());
-  auto elasticEnvName =
-      std::string(ELASTIC_ENV_PREFIX) + std::string(shortName);
+    auto shortName = name.substr(UPSTREAM_ENV_PREFIX.size());
+    auto elasticEnvName = std::string(ELASTIC_ENV_PREFIX) + std::string(shortName);
 
-  const char* value = std::getenv(elasticEnvName.c_str());
-  if (value == nullptr) {
-    return std::nullopt;
-  }
-  return std::string(value);
+    const char *value = std::getenv(elasticEnvName.c_str());
+    if (value == nullptr) {
+        return std::nullopt;
+    }
+    return std::string(value);
 }
 
-std::optional<std::string> ElasticConfigProvider::getIniOptionValue(
-    std::string_view name) {
-  if (name.substr(0, UPSTREAM_INI_PREFIX.size()) != UPSTREAM_INI_PREFIX) {
-    return std::nullopt;
-  }
+std::optional<std::string> ElasticConfigProvider::getIniOptionValue(std::string_view name) {
+    if (name.substr(0, UPSTREAM_INI_PREFIX.size()) != UPSTREAM_INI_PREFIX) {
+        return std::nullopt;
+    }
 
-  auto shortName = name.substr(UPSTREAM_INI_PREFIX.size());
-  auto elasticIniName =
-      std::string(ELASTIC_INI_PREFIX) + std::string(shortName);
+    auto shortName = name.substr(UPSTREAM_INI_PREFIX.size());
+    auto elasticIniName = std::string(ELASTIC_INI_PREFIX) + std::string(shortName);
 
-  auto val = cfg_get_entry(elasticIniName.data(), elasticIniName.length());
-  opentelemetry::php::AutoZval autoZval(val);
-  auto optStringView = autoZval.getOptStringView();
-  if (!optStringView.has_value()) {
-    return std::nullopt;
-  }
-  return std::string(*optStringView);
+    auto val = cfg_get_entry(elasticIniName.data(), elasticIniName.length());
+    opentelemetry::php::AutoZval autoZval(val);
+    auto optStringView = autoZval.getOptStringView();
+    if (!optStringView.has_value()) {
+        return std::nullopt;
+    }
+    return std::string(*optStringView);
 }
 
 std::optional<std::string> ElasticConfigProvider::getDynamicOptionValue(std::string_view name) {
-    // Dynamic options from remote config (OpAmp) are handled by the coordinator.
-    // No Elastic-specific dynamic overrides needed at this time.
+    auto found = dynamicOptions_.find(std::string(name));
+    if (found != dynamicOptions_.end()) {
+        return found->second;
+    }
     return std::nullopt;
 }
 
 void ElasticConfigProvider::update(configFiles_t const &configFiles) {
     configFiles_ = configFiles;
+
+    auto elasticConfig = configFiles_.find("elastic"s);
+    if (elasticConfig == configFiles_.end() || elasticConfig->second.empty()) {
+        dynamicOptions_.clear();
+        return;
+    }
+
+    try {
+        dynamicOptions_ = remapOptions(parseElasticJsonConfig(elasticConfig->second));
+    } catch (std::exception const &e) {
+        ELOG_WARNING(logger_, CONFIG, "Failed to parse elastic remote config JSON: {}", e.what());
+    }
+}
+
+ElasticConfigProvider::optionsMap_t ElasticConfigProvider::parseElasticJsonConfig(std::string const &jsonStr) {
+    optionsMap_t result;
+
+    auto doc = nlohmann::json::parse(jsonStr);
+    if (!doc.is_object()) {
+        return result;
+    }
+
+    for (auto &[key, value] : doc.items()) {
+        if (value.is_string()) {
+            result[key] = value.get<std::string>();
+        } else if (value.is_number_integer()) {
+            result[key] = std::to_string(value.get<int64_t>());
+        } else if (value.is_number_float()) {
+            result[key] = std::to_string(value.get<double>());
+        } else if (value.is_boolean()) {
+            result[key] = value.get<bool>() ? "true" : "false";
+        }
+    }
+
+    return result;
+}
+
+ElasticConfigProvider::optionsMap_t ElasticConfigProvider::remapOptions(optionsMap_t const &remoteOptions) const {
+    optionsMap_t result;
+    for (auto const &opt : remoteOptions) {
+        if (opt.first == "logging_level"sv) {
+            std::string loglevel;
+            if (opt.second == "trace"s) {
+                loglevel = opt.second;
+            } else if (opt.second == "debug"s) {
+                loglevel = opt.second;
+            } else if (opt.second == "info"s) {
+                loglevel = opt.second;
+            } else if (opt.second == "error"s) {
+                loglevel = opt.second;
+            } else if (opt.second == "off"s) {
+                loglevel = opt.second;
+            } else if (opt.second == "warn"s) {
+                loglevel = "warning"s;
+            } else if (opt.second == "fatal"s) {
+                loglevel = "critical"s;
+            } else {
+                loglevel = opt.second; // log level parser with emit warning
+            }
+
+            result[STRINGIFY_HELPER(OTEL_PHP_LOG_LEVEL)] = loglevel;
+            result[STRINGIFY_HELPER(OTEL_PHP_LOG_LEVEL)] = loglevel;
+            result[STRINGIFY_HELPER(OTEL_PHP_LOG_LEVEL_STDERR)] = loglevel;
+            result[STRINGIFY_HELPER(OTEL_PHP_LOG_LEVEL_SYSLOG)] = loglevel;
+            result[STRINGIFY_HELPER(OTEL_PHP_LOG_LEVEL_FILE)] = loglevel;
+            ELOG_DEBUG(logger_, CONFIG, "ElasticConfigProvider remapOptions Mapped remote 'logging_level->{}' to '{}->{}'.", opt.second, STRINGIFY_HELPER(OTEL_PHP_LOG_LEVEL), loglevel);
+        }
+
+        if (opt.first == "infer_spans"sv) {
+            if (opt.second == "true"s) {
+                result[STRINGIFY_HELPER(OTEL_PHP_INFERRED_SPANS_ENABLED)] = "true"s;
+            } else if (opt.second == "false"s) {
+                result[STRINGIFY_HELPER(OTEL_PHP_INFERRED_SPANS_ENABLED)] = "false"s;
+            }
+            ELOG_DEBUG(logger_, CONFIG, "ElasticConfigProvider remapOptions Mapped remote 'infer_spans->{}' to '{}->{}'.", opt.second, STRINGIFY_HELPER(OTEL_PHP_INFERRED_SPANS_ENABLED), result[STRINGIFY_HELPER(OTEL_PHP_INFERRED_SPANS_ENABLED)]);
+        }
+
+        if (opt.first == "opamp_polling_interval"sv) {
+            // Duration values: if plain number, treat as seconds and append "s"
+            // so that convertDurationWithUnit() parses it correctly.
+            // If already has a unit suffix (ms, s, m), pass as-is.
+            // TODO check in kibana that the value is a valid duration
+            bool hasUnit = false;
+            if (!opt.second.empty()) {
+                char last = opt.second.back();
+                hasUnit = (last == 's' || last == 'm');
+            }
+
+            result[STRINGIFY_HELPER(OTEL_PHP_OPAMP_POLLING_INTERVAL)] = hasUnit ? opt.second : opt.second + "s";
+            ELOG_DEBUG(logger_, CONFIG, "ElasticConfigProvider remapOptions Mapped remote 'opamp_polling_interval->{}' to '{}->{}'.", opt.second, STRINGIFY_HELPER(OTEL_PHP_OPAMP_POLLING_INTERVAL), result[STRINGIFY_HELPER(OTEL_PHP_OPAMP_POLLING_INTERVAL)]);
+        }
+    }
+
+    return result;
 }
 
 } // namespace elastic::otel

--- a/elastic_prod/native/libelastic/ElasticConfigProvider.h
+++ b/elastic_prod/native/libelastic/ElasticConfigProvider.h
@@ -22,8 +22,11 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
+#include <memory>
 
 #include "config/OptionValueProviderInterface.h"
+#include "LoggerInterface.h"
 
 namespace elastic::otel {
 
@@ -37,6 +40,10 @@ namespace elastic::otel {
  * getEnvironmentOptionValue("OTEL_PHP_LOG_LEVEL"). This provider translates
  * those to elastic_otel.log_level and ELASTIC_OTEL_LOG_LEVEL respectively,
  * providing backward compatibility for existing Elastic deployments.
+ *
+ * Additionally, parses the "elastic" remote config JSON file (received via
+ * OpAMP) and exposes vendor-specific options (e.g. opamp_polling_interval)
+ * as dynamic option values.
  */
 class ElasticConfigProvider : public opentelemetry::php::config::OptionValueProviderInterface {
 public:
@@ -45,8 +52,19 @@ public:
     std::optional<std::string> getDynamicOptionValue(std::string_view name) override;
     void update(configFiles_t const &configFiles) override;
 
-   private:
+    void setLogger(std::shared_ptr<opentelemetry::php::LoggerInterface> logger) {
+        logger_ = std::move(logger);
+    }
+
+private:
+    using optionsMap_t = std::unordered_map<std::string, std::string>;
+
+    static optionsMap_t parseElasticJsonConfig(std::string const &jsonStr);
+    optionsMap_t remapOptions(optionsMap_t const &remoteOptions) const;
+
     configFiles_t configFiles_;
+    optionsMap_t dynamicOptions_;
+    std::shared_ptr<opentelemetry::php::LoggerInterface> logger_;
 };
 
 } // namespace elastic::otel

--- a/elastic_prod/native/libelastic/ElasticVendor.cpp
+++ b/elastic_prod/native/libelastic/ElasticVendor.cpp
@@ -43,7 +43,21 @@ std::pair<int, std::shared_ptr<opentelemetry::php::config::OptionValueProviderIn
 ElasticVendor::getOptionValueProvider() {
     // Priority 10: vendor options override default (priority 0) but can be
     // overridden by dynamic options from coordinator
-    return {10, std::make_shared<ElasticConfigProvider>()};
+    if (!configProvider_) {
+        configProvider_ = std::make_shared<ElasticConfigProvider>();
+    }
+    return {10, configProvider_};
+}
+
+void ElasticVendor::setLogger(std::shared_ptr<opentelemetry::php::LoggerInterface> logger) {
+    if (!configProvider_) {
+        configProvider_ = std::make_shared<ElasticConfigProvider>();
+    }
+    configProvider_->setLogger(std::move(logger));
+}
+
+std::map<std::string, std::string> ElasticVendor::getAdditionalResourceAttributes() {
+    return {};
 }
 
 } // namespace elastic::otel

--- a/elastic_prod/native/libelastic/ElasticVendor.h
+++ b/elastic_prod/native/libelastic/ElasticVendor.h
@@ -21,7 +21,13 @@
 
 #include "VendorCustomizationsInterface.h"
 
+#include <map>
+#include <memory>
+#include <string>
+
 namespace elastic::otel {
+
+class ElasticConfigProvider;
 
 class ElasticVendor : public opentelemetry::php::VendorCustomizationsInterface {
 public:
@@ -31,6 +37,11 @@ public:
     std::string getUserAgent() const override;
 
     std::pair<int, std::shared_ptr<opentelemetry::php::config::OptionValueProviderInterface>> getOptionValueProvider() override;
+    void setLogger(std::shared_ptr<opentelemetry::php::LoggerInterface> logger) override;
+    std::map<std::string, std::string> getAdditionalResourceAttributes() override;
+
+private:
+    std::shared_ptr<ElasticConfigProvider> configProvider_;
 };
 
 } // namespace elastic::otel

--- a/elastic_prod/native/libelastic/elastic_vendor_inject.cmake
+++ b/elastic_prod/native/libelastic/elastic_vendor_inject.cmake
@@ -71,11 +71,16 @@ function(_elastic_create_and_link)
             PRIVATE
                 "${CMAKE_SOURCE_DIR}/libcommon/code"
                 "${CMAKE_SOURCE_DIR}/libphpbridge/code"
+                "${CMAKE_BINARY_DIR}/libcommon/code/generated"  # for LogFeature.h etc.
                 "${php-headers-${_php_version}_INCLUDE_DIRS}"
                 "${php-headers-${_php_version}_INCLUDE_DIRS}/ext"
                 "${php-headers-${_php_version}_INCLUDE_DIRS}/main"
                 "${php-headers-${_php_version}_INCLUDE_DIRS}/TSRM"
                 "${php-headers-${_php_version}_INCLUDE_DIRS}/Zend"
+        )
+
+        target_link_libraries(${_elastic}
+            PRIVATE nlohmann_json::nlohmann_json
         )
 
         if(TARGET ${_target})

--- a/elastic_prod/php/Elastic/OTel/OpAmp/ElasticRemoteConfigParser.php
+++ b/elastic_prod/php/Elastic/OTel/OpAmp/ElasticRemoteConfigParser.php
@@ -58,6 +58,10 @@ final class ElasticRemoteConfigParser
     /** @see https://github.com/elastic/kibana/blob/v9.1.0/.../edot_sdk_settings.ts#L104 */
     private const SEND_LOGS = 'send_logs';
 
+    // Options handled exclusively by the native side (ElasticConfigProvider)
+    private const INFER_SPANS = 'infer_spans';
+    private const OPAMP_POLLING_INTERVAL = 'opamp_polling_interval';
+
     // OTel env var names (inlined to avoid scoped class dependency)
     // @see OpenTelemetry\SDK\Common\Configuration\Variables
     private const OTEL_LOG_LEVEL = 'OTEL_LOG_LEVEL';
@@ -80,7 +84,7 @@ final class ElasticRemoteConfigParser
      */
     public static function parseAndApply(array $config): void
     {
-        self::logDebug('Parsing remote config', $config);
+        self::logDebug('Parsing remote config ' . json_encode($config, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE), __LINE__, __FUNCTION__);
 
         foreach ($config as $optName => $optVal) {
             match ($optName) {
@@ -91,7 +95,10 @@ final class ElasticRemoteConfigParser
                 self::SEND_TRACES => self::applySendSignal($optName, $optVal, self::OTEL_TRACES_EXPORTER),
                 self::SEND_METRICS => self::applySendSignal($optName, $optVal, self::OTEL_METRICS_EXPORTER),
                 self::SEND_LOGS => self::applySendSignal($optName, $optVal, self::OTEL_LOGS_EXPORTER),
-                default => self::logDebug('Unsupported remote config option', ['option' => $optName]),
+                // Handled by native side (ElasticConfigProvider)
+                self::INFER_SPANS => null,
+                self::OPAMP_POLLING_INTERVAL => null,
+                default => self::logDebug('Unsupported remote config option: ' . $optName, __LINE__, __FUNCTION__),
             };
         }
 
@@ -101,7 +108,7 @@ final class ElasticRemoteConfigParser
     private static function applyLoggingLevel(mixed $val): void
     {
         if (!is_string($val)) {
-            self::logError('logging_level value is not a string: ' . get_debug_type($val));
+            self::logError('logging_level value is not a string: ' . get_debug_type($val), __LINE__, __FUNCTION__);
             return;
         }
 
@@ -117,25 +124,24 @@ final class ElasticRemoteConfigParser
         };
 
         if ($otelLevel === null) {
-            self::logError("Unknown logging_level value: $val");
+            self::logError("Unknown logging_level value: $val", __LINE__, __FUNCTION__);
             return;
         }
 
-        // OTel SDK reads log level directly from $_SERVER
-        $_SERVER[self::OTEL_LOG_LEVEL] = $otelLevel;
-        self::logDebug('Applied logging_level', ['remote' => $val, 'otel' => $otelLevel]);
+        self::setEnvVar(self::OTEL_LOG_LEVEL, $otelLevel);
+        self::logDebug("Applied logging_level remote=$val otel=$otelLevel", __LINE__, __FUNCTION__);
     }
 
     private static function applySamplingRate(mixed $val): void
     {
         if (!is_numeric($val)) {
-            self::logError('sampling_rate value is not numeric: ' . get_debug_type($val));
+            self::logError('sampling_rate value is not numeric: ' . get_debug_type($val), __LINE__, __FUNCTION__);
             return;
         }
 
         $rate = floatval($val);
         if ($rate < 0 || $rate > 1) {
-            self::logError("sampling_rate value out of range [0,1]: $rate");
+            self::logError("sampling_rate value out of range [0,1]: $rate", __LINE__, __FUNCTION__);
             return;
         }
 
@@ -144,14 +150,14 @@ final class ElasticRemoteConfigParser
             self::setEnvVar(self::OTEL_TRACES_SAMPLER, self::VALUE_PARENT_BASED_TRACE_ID_RATIO);
         } elseif ($currentSampler !== self::VALUE_PARENT_BASED_TRACE_ID_RATIO) {
             self::logDebug(
-                'OTEL_TRACES_SAMPLER is set to incompatible value, not applying sampling_rate',
-                ['sampler' => $currentSampler, 'rate' => $rate],
+                "OTEL_TRACES_SAMPLER is set to incompatible value, not applying sampling_rate sampler=$currentSampler rate=$rate",
+                __LINE__, __FUNCTION__,
             );
             return;
         }
 
         self::setEnvVar(self::OTEL_TRACES_SAMPLER_ARG, strval($rate));
-        self::logDebug('Applied sampling_rate', ['rate' => $rate]);
+        self::logDebug("Applied sampling_rate rate=$rate", __LINE__, __FUNCTION__);
     }
 
     private static function applySendSignal(string $optName, mixed $val, string $otelEnvVar): void
@@ -163,12 +169,12 @@ final class ElasticRemoteConfigParser
 
         if (!$shouldSend) {
             self::setEnvVar($otelEnvVar, self::VALUE_NONE);
-            self::logDebug("Applied $optName=false", ['envVar' => $otelEnvVar]);
+            self::logDebug("Applied $optName=false envVar=$otelEnvVar", __LINE__, __FUNCTION__);
         } else {
             // Remove any prior override so the default exporter resumes.
             // putenv() values persist across PHP-FPM requests in the same worker.
             self::unsetEnvVar($otelEnvVar);
-            self::logDebug("Applied $optName=true (unset override)", ['envVar' => $otelEnvVar]);
+            self::logDebug("Applied $optName=true (unset override) envVar=$otelEnvVar", __LINE__, __FUNCTION__);
         }
     }
 
@@ -187,14 +193,14 @@ final class ElasticRemoteConfigParser
 
         if ($deactivateAll) {
             self::setEnvVar(self::OTEL_PHP_DISABLED_INSTRUMENTATIONS, self::DISABLED_INSTRUMENTATIONS_ALL);
-            self::logDebug('Applied deactivate_all_instrumentations=true');
+            self::logDebug('Applied deactivate_all_instrumentations=true', __LINE__, __FUNCTION__);
             return;
         }
 
         if (array_key_exists(self::DEACTIVATE_INSTRUMENTATIONS, $config)) {
             $val = $config[self::DEACTIVATE_INSTRUMENTATIONS];
             if (!is_string($val)) {
-                self::logError('deactivate_instrumentations value is not a string: ' . get_debug_type($val));
+                self::logError('deactivate_instrumentations value is not a string: ' . get_debug_type($val), __LINE__, __FUNCTION__);
                 return;
             }
 
@@ -202,7 +208,7 @@ final class ElasticRemoteConfigParser
             // workers putenv() values persist across requests, causing stale entries
             // from previous remote configs to accumulate.
             self::setEnvVar(self::OTEL_PHP_DISABLED_INSTRUMENTATIONS, $val);
-            self::logDebug('Applied deactivate_instrumentations', ['value' => $val]);
+            self::logDebug("Applied deactivate_instrumentations value=$val", __LINE__, __FUNCTION__);
         }
     }
 
@@ -223,7 +229,7 @@ final class ElasticRemoteConfigParser
                 return false;
             }
         }
-        self::logError("Cannot parse $optName as bool: " . get_debug_type($val));
+        self::logError("Cannot parse $optName as bool: " . get_debug_type($val), __LINE__, __FUNCTION__);
         return null;
     }
 
@@ -262,17 +268,36 @@ final class ElasticRemoteConfigParser
         return $val !== false ? $val : null;
     }
 
-    /**
-     * @param array<string, mixed> $context
-     */
-    private static function logDebug(string $message, array $context = []): void
+    private static function logDebug(string $message, int $lineNumber, string $func): void
     {
-        $contextStr = $context !== [] ? ' ' . json_encode($context, JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE) : '';
-        error_log('[EDOT] [DEBUG] [ElasticRemoteConfigParser] ' . $message . $contextStr);
+        self::ensureClassesAliased();
+        self::logWithLevel(\OpenTelemetry\Distro\BootstrapStageLogger::LEVEL_DEBUG, $message, $lineNumber, $func);
     }
 
-    private static function logError(string $message): void
+    private static function logError(string $message, int $lineNumber, string $func): void
     {
-        error_log('[EDOT] [ERROR] [ElasticRemoteConfigParser] ' . $message);
+        self::ensureClassesAliased();
+        self::logWithLevel(\OpenTelemetry\Distro\BootstrapStageLogger::LEVEL_ERROR, $message, $lineNumber, $func);
+    }
+
+    private static function ensureClassesAliased(): void
+    {
+        static $aliased = false;
+        if ($aliased) {
+            return;
+        }
+        $prefix = \OpenTelemetry\Distro\OTelDistroScoperConfig::PREFIX . '\\';
+        if (!class_exists(\OpenTelemetry\Distro\BootstrapStageLogger::class, false)) {
+            class_alias($prefix . 'OpenTelemetry\\Distro\\BootstrapStageLogger', 'OpenTelemetry\\Distro\\BootstrapStageLogger');
+        }
+        if (!class_exists(\OpenTelemetry\Distro\Log\LogFeature::class, false)) {
+            class_alias($prefix . 'OpenTelemetry\\Distro\\Log\\LogFeature', 'OpenTelemetry\\Distro\\Log\\LogFeature');
+        }
+        $aliased = true;
+    }
+
+    private static function logWithLevel(int $statementLevel, string $message, int $lineNumber, string $func): void
+    {
+        \OpenTelemetry\Distro\BootstrapStageLogger::logWithFeatureAndLevel(\OpenTelemetry\Distro\Log\LogFeature::OPAMP, $statementLevel, $message, 'ElasticRemoteConfigParser.php', $lineNumber, __CLASS__, $func);
     }
 }


### PR DESCRIPTION
- JSON parsing and option remapping in `ElasticConfigProvider` (`logging_level`, `infer_spans`, `opamp_polling_interval`) with level translation and duration unit handling
- Implement `ElasticVendor::setLogger()` and `getAdditionalResourceAttributes()`
- Fix `ElasticRemoteConfigParser`: class aliasing, native-side option handling, relative log path, all log level sinks mapped

#### updated upstream adding improved OpAMP remote config handling
